### PR TITLE
PDF Total Reviews Count

### DIFF
--- a/src/content/Dashboards/Tasks/ExportPDF/DocPDF.tsx
+++ b/src/content/Dashboards/Tasks/ExportPDF/DocPDF.tsx
@@ -22,8 +22,10 @@ function DocPDF({
 }) {
   // Filter reviews based on selected sources and date range
   const filteredReviews = (reviewsData?.data || []).filter((review) => {
-    // Parse dates properly
-    const reviewDate = new Date(review.raw_date); // Use raw_date instead of date
+    // avoiding timezone shifts
+    const [year, month, day] = review.raw_date.split("-").map(Number);
+    const reviewDate = new Date(year, month - 1, day);
+
     const start = startDate ? new Date(startDate) : null;
     const end = endDate ? new Date(endDate) : null;
 


### PR DESCRIPTION
When setting custom dates when exporting, the JavaScript date function shifted dates to local time, I added manual shifting so that the first and last days of the month could be included in the report.